### PR TITLE
Add a Settings page & Log category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
 Binaries/
 Intermediate/
 /node_modules/
+
+# Visual Studio 2015 cache/options directory
+.vs/
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile

--- a/Source/GameJoltAPI/Private/GameJoltAPI.cpp
+++ b/Source/GameJoltAPI/Private/GameJoltAPI.cpp
@@ -30,7 +30,6 @@ void FGameJoltAPIModule::ShutdownModule()
 		SettingsModule->UnregisterSettings("Project", "Plugins", "GameJoltAPI");
 	}
 
-	UE_LOG(GameJoltAPI, Log, TEXT("Game Jolt API module has been unloaded!"));
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GameJoltAPI/Private/GameJoltAPI.cpp
+++ b/Source/GameJoltAPI/Private/GameJoltAPI.cpp
@@ -21,7 +21,6 @@ void FGameJoltAPIModule::StartupModule()
 		);
 	}
 
-	UE_LOG(GameJoltAPI, Log, TEXT("Game Jolt API module has been loaded!"));
 }
 
 void FGameJoltAPIModule::ShutdownModule()

--- a/Source/GameJoltAPI/Private/GameJoltAPI.cpp
+++ b/Source/GameJoltAPI/Private/GameJoltAPI.cpp
@@ -1,13 +1,39 @@
 // Copyright by Nick Lamprecht (2020-2021)
 
 #include "GameJoltAPI.h"
+#include "GameJoltSettings.h"
+#include "Developer/Settings/Public/ISettingsModule.h"
+
+DEFINE_LOG_CATEGORY(GameJoltAPI);
+
+#define LOCTEXT_NAMESPACE "GameJoltAPI"
 
 void FGameJoltAPIModule::StartupModule()
 {
+	if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
+	{
+		UGameJoltSettings* PluginSettings = GetMutableDefault<UGameJoltSettings>();
+
+		SettingsModule->RegisterSettings("Project", "Plugins", "GameJoltAPI",
+			LOCTEXT("RuntimeSettingsName", "Game Jolt"),
+			LOCTEXT("RuntimeSettingsDescription", "Configure the Game Jolt API Plugin"),
+			PluginSettings
+		);
+	}
+
+	UE_LOG(GameJoltAPI, Log, TEXT("Game Jolt API module has been loaded!"));
 }
 
 void FGameJoltAPIModule::ShutdownModule()
 {
+	if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
+	{
+		SettingsModule->UnregisterSettings("Project", "Plugins", "GameJoltAPI");
+	}
+
+	UE_LOG(GameJoltAPI, Log, TEXT("Game Jolt API module has been unloaded!"));
 }
+
+#undef LOCTEXT_NAMESPACE
 
 IMPLEMENT_MODULE(FGameJoltAPIModule, GameJoltAPI)

--- a/Source/GameJoltAPI/Private/GameJoltSubsystem.cpp
+++ b/Source/GameJoltAPI/Private/GameJoltSubsystem.cpp
@@ -4,6 +4,24 @@
 #include "Kismet/GameplayStatics.h"
 #include "AsyncActions/Users/Login.h"
 #include "AsyncActions/Users/AutoLogin.h"
+#include "GameJoltAPI.h"
+
+void UGameJoltSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+    Super::Initialize(Collection);
+
+    if (UGameJoltSettings* Settings = UGameJoltSettings::Get())
+    {
+        GameID = Settings->GameID;
+        PrivateKey = Settings->PrivateKey;
+        Server = Settings->GetServer();
+        Version = Settings->GetVersion();
+    }
+    else
+    {
+        UE_LOG(GameJoltAPI, Warning, TEXT("Could not automatically initialize Game Jolt API. Please initialize manually!"));
+    }
+}
 
 void UGameJoltSubsystem::Setup(UObject* WCO, const int32 gameID, const FString privateKey, const FString server, const FString version)
 {

--- a/Source/GameJoltAPI/Private/GameJoltSubsystem.cpp
+++ b/Source/GameJoltAPI/Private/GameJoltSubsystem.cpp
@@ -10,17 +10,16 @@ void UGameJoltSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
     Super::Initialize(Collection);
 
-    if (UGameJoltSettings* Settings = UGameJoltSettings::Get())
-    {
-        GameID = Settings->GameID;
-        PrivateKey = Settings->PrivateKey;
-        Server = Settings->GetServer();
-        Version = Settings->GetVersion();
-    }
-    else
+    if (!UGameJoltSettings* Settings = UGameJoltSettings::Get())
     {
         UE_LOG(GameJoltAPI, Warning, TEXT("Could not automatically initialize Game Jolt API. Please initialize manually!"));
+        return;
     }
+
+    GameID = Settings->GameID;
+    PrivateKey = Settings->PrivateKey;
+    Server = Settings->GetServer();
+    Version = Settings->GetVersion();
 }
 
 void UGameJoltSubsystem::Setup(UObject* WCO, const int32 gameID, const FString privateKey, const FString server, const FString version)

--- a/Source/GameJoltAPI/Public/GameJoltAPI.h
+++ b/Source/GameJoltAPI/Public/GameJoltAPI.h
@@ -5,6 +5,8 @@
 #include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
 
+DECLARE_LOG_CATEGORY_EXTERN(GameJoltAPI, All, All)
+
 class FGameJoltAPIModule : public IModuleInterface
 {
 public:

--- a/Source/GameJoltAPI/Public/GameJoltSettings.h
+++ b/Source/GameJoltAPI/Public/GameJoltSettings.h
@@ -17,7 +17,7 @@ public:
 		int32 GameID = 0;
 
 	UPROPERTY(config, EditAnywhere, Category = "Gamejolt")
-		FString PrivateKey = "Null";
+		FString PrivateKey = "";
 
 	UPROPERTY(config, EditAnywhere, Category = "Gamejolt|API")
 		FString Server = "https://api.gamejolt.com/api/game/";

--- a/Source/GameJoltAPI/Public/GameJoltSettings.h
+++ b/Source/GameJoltAPI/Public/GameJoltSettings.h
@@ -1,0 +1,46 @@
+// Contributed by @RedCraft86
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "GameJoltSettings.generated.h"
+
+UCLASS(config = Game, defaultconfig)
+class UGameJoltSettings : public UObject
+{
+	GENERATED_BODY()
+
+public:
+
+	UPROPERTY(config, EditAnywhere, Category = "Gamejolt")
+		int32 GameID = 0;
+
+	UPROPERTY(config, EditAnywhere, Category = "Gamejolt")
+		FString PrivateKey = "Null";
+
+	UPROPERTY(config, EditAnywhere, Category = "Gamejolt|API")
+		FString Server = "https://api.gamejolt.com/api/game/";
+
+	UPROPERTY(config, EditAnywhere, Category = "Gamejolt|API")
+		FString Version = "v1_2";
+
+	/** Static getter to get the settings object. */
+	static FORCEINLINE UGameJoltSettings* Get()
+	{
+		UGameJoltSettings* Settings = GetMutableDefault<UGameJoltSettings>();
+		check(Settings);
+
+		return Settings;
+	}
+
+	FString GetServer() const
+	{
+		return Server.IsEmpty() ? "https://api.gamejolt.com/api/game/" : Server;
+	}
+
+	FString GetVersion() const
+	{
+		return Version.IsEmpty() ? "v1_2" : Version;
+	}
+};

--- a/Source/GameJoltAPI/Public/GameJoltSubsystem.h
+++ b/Source/GameJoltAPI/Public/GameJoltSubsystem.h
@@ -34,6 +34,8 @@ class GAMEJOLTAPI_API UGameJoltSubsystem : public UGameInstanceSubsystem
 
 public:
 
+    virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+
 	/**
      * Sets required information for all API requests
      * @param Game_ID Required. Can be found in your game's dashboard


### PR DESCRIPTION
A settings section is added to "Project Settings > Plugins > Game Jolt". 
If filled out appropriately, Game ID, Private Key, Server and Version will be set up automatically by the subsystem without ever having to call the Setup function.

A logging category "GameJoltAPI" has been added as well, this may be used to log errors the user may not have easy access to.

gitignore is updated as it kept pulling unnecessary files from my device